### PR TITLE
[FIX] use query parameters for get endpoints

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,18 +4,25 @@ const BASE_API = 'https://api.aircall.io/v1'
 
 export type Options = Record<string, any>
 
+type Method = 'get' | 'post' | 'put' | 'delete'
+
 export default class API {
   constructor(private apiID: string, private apiToken: string) { }
 
-  query(method: string, endpoint: string, callback: Function, options?: Options) {
-    request(method, BASE_API + endpoint)
-      .auth(this.apiID, this.apiToken)
-      .send(options)
-      .end(function (err: any, res: any) {
-        if (err) return callback(err)
-        if ([200, 201, 204].indexOf(res.statusCode) < 0) return callback(new Error('[' + res.statusCode + '] Bad response: ' + res.text))
-        return callback(null, res.body)
-      })
+  query(method: Method, endpoint: string, callback: Function, options?: Options) {
+    const req = request(method, BASE_API + endpoint).auth(this.apiID, this.apiToken)
+
+    if (method === 'get') {
+      req.query(options ?? {})
+    } else {
+      req.send(options)
+    }
+
+    req.end((err: any, res: any) => {
+      if (err) return callback(err)
+      if ([200, 201, 204].indexOf(res.statusCode) < 0) return callback(new Error('[' + res.statusCode + '] Bad response: ' + res.text))
+      return callback(null, res.body)
+    })
   }
 
   get(endpoint: string, callback: Function, options?: Options) {


### PR DESCRIPTION
It's not possible to send a body in GET requests due to cloudfront limitations. We get 403 Forbidden errors in this case.
This PR sends get parameters into query parameters instead of body.


https://onenr.io/0LREkJn8lQa